### PR TITLE
Routes fix

### DIFF
--- a/now.json
+++ b/now.json
@@ -3,7 +3,7 @@
     "name": "nodejs-express",
     "alias": ["adelerjeremy.com"],
     "builds": [
-        {   "src": "*.js", 
+        {   "src": "index.js", 
             "use": "@now/node-server",
             "config": { 
                 "maxLambdaSize": "50mb"
@@ -12,7 +12,7 @@
         {"src": "/public/**", "use": "@now/static"}
     ],
     "routes": [
-        {"src": "/public/(.*)", "dest": "/$1"},
+        {"src": "/public/(.*)", "dest": "/public/$1"},
         { "src": "/(.*)", "dest": "/index.js" }
     ]
 }


### PR DESCRIPTION
Not every `.js` file needs to generate a lambda. 
And public needs the prefix otherwise it will fail.